### PR TITLE
Add floating accessibility & translation controls with i18n and accessibility contexts

### DIFF
--- a/src/app/components/FloatingControls.tsx
+++ b/src/app/components/FloatingControls.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import { Accessibility, Languages, Check } from "lucide-react";
+import { useI18n } from "../contexts/I18nContext";
+import { useAccessibility } from "../contexts/AccessibilityContext";
+
+const languageOptions = [
+    { value: "en", labelKey: "accessibility.languageEnglish" },
+    { value: "pt", labelKey: "accessibility.languagePortuguese" },
+] as const;
+
+const textSizeOptions = [
+    { value: "normal", labelKey: "accessibility.textSizeNormal" },
+    { value: "large", labelKey: "accessibility.textSizeLarge" },
+    { value: "xl", labelKey: "accessibility.textSizeXL" },
+] as const;
+
+export default function FloatingControls() {
+    const { language, setLanguage, t } = useI18n();
+    const { highContrast, setHighContrast, textSize, setTextSize, reduceMotion, setReduceMotion } = useAccessibility();
+    const [openPanel, setOpenPanel] = useState<"accessibility" | "language" | null>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (!containerRef.current) return;
+            if (!containerRef.current.contains(event.target as Node)) {
+                setOpenPanel(null);
+            }
+        };
+        document.addEventListener("mousedown", handleClickOutside);
+        return () => document.removeEventListener("mousedown", handleClickOutside);
+    }, []);
+
+    const togglePanel = (panel: "accessibility" | "language") => {
+        setOpenPanel((prev) => (prev === panel ? null : panel));
+    };
+
+    return (
+        <div
+            ref={containerRef}
+            className="fixed left-4 top-1/2 z-[9999] flex -translate-y-1/2 flex-col gap-3"
+        >
+            <div className="relative">
+                <button
+                    type="button"
+                    onClick={() => togglePanel("accessibility")}
+                    aria-label={t("accessibility.accessibilityLabel")}
+                    aria-expanded={openPanel === "accessibility"}
+                    className="group flex items-center"
+                >
+                    <span className="flex h-12 w-12 items-center justify-center rounded-full bg-white text-black shadow-lg transition-transform duration-200 group-hover:scale-105">
+                        <Accessibility className="h-6 w-6" />
+                    </span>
+                    <span className="ml-3 max-w-0 overflow-hidden rounded-full bg-white/90 px-3 py-1 text-xs font-semibold text-black opacity-0 shadow-lg transition-all duration-300 group-hover:max-w-[160px] group-hover:opacity-100">
+                        {t("accessibility.accessibilityLabel")}
+                    </span>
+                </button>
+
+                {openPanel === "accessibility" && (
+                    <div className="absolute left-14 top-0 w-64 rounded-2xl border border-white/20 bg-black/90 p-4 text-white shadow-2xl backdrop-blur">
+                        <div className="mb-3 text-sm font-semibold text-white">
+                            {t("accessibility.accessibilityTitle")}
+                        </div>
+                        <div className="space-y-4 text-sm">
+                            <label className="flex items-center justify-between gap-3">
+                                <span className="text-white/80">{t("accessibility.highContrast")}</span>
+                                <button
+                                    type="button"
+                                    onClick={() => setHighContrast(!highContrast)}
+                                    className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${highContrast ? "bg-red-500" : "bg-white/20"}`}
+                                >
+                                    <span
+                                        className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${highContrast ? "translate-x-5" : "translate-x-1"}`}
+                                    />
+                                </button>
+                            </label>
+
+                            <div>
+                                <div className="mb-2 text-white/80">{t("accessibility.textSize")}</div>
+                                <div className="flex flex-wrap gap-2">
+                                    {textSizeOptions.map((option) => (
+                                        <button
+                                            key={option.value}
+                                            type="button"
+                                            onClick={() => setTextSize(option.value)}
+                                            className={`flex items-center gap-1 rounded-full border px-3 py-1 text-xs transition-colors ${
+                                                textSize === option.value
+                                                    ? "border-red-400 bg-red-500/20 text-white"
+                                                    : "border-white/20 text-white/70 hover:border-white/40"
+                                            }`}
+                                        >
+                                            {textSize === option.value && <Check className="h-3 w-3" />}
+                                            {t(option.labelKey)}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+
+                            <label className="flex items-center justify-between gap-3">
+                                <span className="text-white/80">{t("accessibility.reduceMotion")}</span>
+                                <button
+                                    type="button"
+                                    onClick={() => setReduceMotion(!reduceMotion)}
+                                    className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${reduceMotion ? "bg-red-500" : "bg-white/20"}`}
+                                >
+                                    <span
+                                        className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${reduceMotion ? "translate-x-5" : "translate-x-1"}`}
+                                    />
+                                </button>
+                            </label>
+                        </div>
+                    </div>
+                )}
+            </div>
+
+            <div className="relative">
+                <button
+                    type="button"
+                    onClick={() => togglePanel("language")}
+                    aria-label={t("accessibility.translationLabel")}
+                    aria-expanded={openPanel === "language"}
+                    className="group flex items-center"
+                >
+                    <span className="flex h-12 w-12 items-center justify-center rounded-full bg-white text-black shadow-lg transition-transform duration-200 group-hover:scale-105">
+                        <Languages className="h-6 w-6" />
+                    </span>
+                    <span className="ml-3 max-w-0 overflow-hidden rounded-full bg-white/90 px-3 py-1 text-xs font-semibold text-black opacity-0 shadow-lg transition-all duration-300 group-hover:max-w-[160px] group-hover:opacity-100">
+                        {t("accessibility.translationLabel")}
+                    </span>
+                </button>
+
+                {openPanel === "language" && (
+                    <div className="absolute left-14 top-0 w-64 rounded-2xl border border-white/20 bg-black/90 p-4 text-white shadow-2xl backdrop-blur">
+                        <div className="mb-3 text-sm font-semibold text-white">
+                            {t("accessibility.languageTitle")}
+                        </div>
+                        <div className="flex flex-col gap-2">
+                            {languageOptions.map((option) => (
+                                <button
+                                    key={option.value}
+                                    type="button"
+                                    onClick={() => setLanguage(option.value)}
+                                    className={`flex items-center justify-between rounded-lg border px-3 py-2 text-sm transition-colors ${
+                                        language === option.value
+                                            ? "border-red-400 bg-red-500/20 text-white"
+                                            : "border-white/15 text-white/75 hover:border-white/35"
+                                    }`}
+                                >
+                                    {t(option.labelKey)}
+                                    {language === option.value && <Check className="h-4 w-4" />}
+                                </button>
+                            ))}
+                        </div>
+                        <p className="mt-3 text-xs text-white/60">{t("accessibility.languageNotice")}</p>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/app/components/FloatingControls.tsx
+++ b/src/app/components/FloatingControls.tsx
@@ -40,7 +40,8 @@ export default function FloatingControls() {
     return (
         <div
             ref={containerRef}
-            className="fixed left-4 top-1/2 z-[9999] flex -translate-y-1/2 flex-col gap-3"
+            className="fixed left-4 z-[9999] flex flex-col gap-3"
+            style={{ top: "50%", transform: "translateY(-50%)" }}
         >
             <div className="relative">
                 <button

--- a/src/app/components/FloatingControls.tsx
+++ b/src/app/components/FloatingControls.tsx
@@ -41,7 +41,7 @@ export default function FloatingControls() {
         <div
             ref={containerRef}
             className="fixed left-4 z-[9999] flex flex-col gap-3"
-            style={{ top: "50%", transform: "translateY(-50%)" }}
+            style={{ top: "50vh", transform: "translateY(-50%)" }}
         >
             <div className="relative">
                 <button

--- a/src/app/components/Timeline.tsx
+++ b/src/app/components/Timeline.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import gsap from "gsap";
 import { motion, useReducedMotion } from "framer-motion";
 import { ExternalLink, CalendarDays, Clock3 } from "lucide-react";
+import { useI18n } from "../contexts/I18nContext";
 
 const GITHUB_OWNER = "TheusHen";
 const GITHUB_REPO = "TheusHen";
@@ -43,6 +44,7 @@ export default function Timeline() {
     const itemsRef = useRef<HTMLDivElement | null>(null);
     const [items, setItems] = useState<TimelineItem[]>([]);
     const [activeId, setActiveId] = useState<string | null>(null);
+    const { t } = useI18n();
 
     useEffect(() => {
         let cancelled = false;
@@ -117,7 +119,7 @@ export default function Timeline() {
                         transition={{ duration: 0.7, ease: [0.22, 1, 0.36, 1] }}
                         className="text-balance text-2xl font-semibold tracking-tight text-white sm:text-3xl"
                     >
-                        Timeline
+                        {t("timeline.title")}
                     </motion.h2>
 
                     <motion.p
@@ -126,7 +128,7 @@ export default function Timeline() {
                         transition={{ duration: 0.75, delay: 0.05, ease: [0.22, 1, 0.36, 1] }}
                         className="max-w-2xl text-pretty text-sm text-white/65 sm:text-base"
                     >
-                        Scroll down to see the timeline. Each point opens the full markdown entry on GitHub.
+                        {t("timeline.subtitle")}
                     </motion.p>
                 </div>
 
@@ -149,7 +151,7 @@ export default function Timeline() {
                                                 "outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/60 focus-visible:ring-offset-0",
                                             ].join(" ")}
                                             style={{ width: NODE_SIZE * 2.3, height: NODE_SIZE * 2.3, top: "1.5rem" }}
-                                            aria-label={`Open ${it.title} on GitHub`}
+                                            aria-label={t("timeline.openOnGithub", { title: it.title })}
                                         >
                                             <span
                                                 className={[
@@ -219,7 +221,7 @@ export default function Timeline() {
                                                         </div>
 
                                                         <div className="text-sm leading-relaxed text-white/55">
-                                                            Click to open the full entry on GitHub.
+                                                            {t("timeline.cardHint")}
                                                         </div>
                                                     </div>
 
@@ -238,8 +240,7 @@ export default function Timeline() {
                     </div>
                 ) : (
                     <div className="mt-8 rounded-2xl border border-white/10 bg-white/[0.03] p-5 text-sm text-white/70">
-                        No markdown files found in /{TIMELINE_FOLDER}. Add files like 2026-01-05.md with a first line
-                        heading: &apos;# Title&apos;.
+                        {t("timeline.emptyState", { folder: TIMELINE_FOLDER })}
                     </div>
                 )}
             </div>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -4,9 +4,11 @@ import { FaArrowLeft, FaGithub, FaEnvelope, FaInstagram, FaLinkedin } from "reac
 import Link from "next/link";
 import { ReactNode, useEffect, useState } from "react";
 import './styles.css'
+import { useI18n } from "../contexts/I18nContext";
 
 export default function ContactPage() {
     const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
+    const { t } = useI18n();
 
     useEffect(() => {
         const handleMouseMove = (e: MouseEvent) => {
@@ -33,10 +35,10 @@ export default function ContactPage() {
                     </Link>
                     <div className="flex space-x-4">
                         <Link href="/projects" className="text-lg hover:text-red-400 transition-colors">
-                            Projects
+                            {t("nav.projects")}
                         </Link>
                         <Link href="/contact" className="text-lg hover:text-red-400 transition-colors">
-                            Contact
+                            {t("nav.contact")}
                         </Link>
                     </div>
                 </div>
@@ -47,25 +49,25 @@ export default function ContactPage() {
                     <ContactCard
                         icon={<FaGithub className="text-4xl" />}
                         title="TheusHen"
-                        subtitle="Github"
+                        subtitle={t("contact.github")}
                         link="https://github.com/TheusHen"
                     />
                     <ContactCard
                         icon={<FaEnvelope className="text-4xl" />}
                         title="dev@theushen.me"
-                        subtitle="Email"
+                        subtitle={t("contact.email")}
                         link="mailto:dev@theushen.me"
                     />
                     <ContactCard
                         icon={<FaInstagram className="text-4xl" />}
                         title="@mmatheus_henriquee"
-                        subtitle="Instagram"
+                        subtitle={t("contact.instagram")}
                         link="https://www.instagram.com/mmatheus_henriquee"
                     />
                     <ContactCard
                         icon={<FaLinkedin className="text-4xl" />}
                         title="Matheus Henrique"
-                        subtitle="LinkedIn"
+                        subtitle={t("contact.linkedin")}
                         link="https://www.linkedin.com/in/matheus-henrique-741776367/"
                     />
                 </div>

--- a/src/app/contexts/AccessibilityContext.tsx
+++ b/src/app/contexts/AccessibilityContext.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+type TextSize = "normal" | "large" | "xl";
+
+type AccessibilityContextValue = {
+    highContrast: boolean;
+    setHighContrast: (value: boolean) => void;
+    textSize: TextSize;
+    setTextSize: (value: TextSize) => void;
+    reduceMotion: boolean;
+    setReduceMotion: (value: boolean) => void;
+};
+
+const STORAGE_KEY = "theushen-accessibility";
+
+const defaultState = {
+    highContrast: false,
+    textSize: "normal" as TextSize,
+    reduceMotion: false,
+};
+
+const AccessibilityContext = createContext<AccessibilityContextValue | undefined>(undefined);
+
+export function AccessibilityProvider({ children }: { children: React.ReactNode }) {
+    const [highContrast, setHighContrast] = useState(defaultState.highContrast);
+    const [textSize, setTextSize] = useState<TextSize>(defaultState.textSize);
+    const [reduceMotion, setReduceMotion] = useState(defaultState.reduceMotion);
+
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        const stored = window.localStorage.getItem(STORAGE_KEY);
+        if (stored) {
+            try {
+                const parsed = JSON.parse(stored) as Partial<typeof defaultState>;
+                if (typeof parsed.highContrast === "boolean") setHighContrast(parsed.highContrast);
+                if (parsed.textSize === "normal" || parsed.textSize === "large" || parsed.textSize === "xl") {
+                    setTextSize(parsed.textSize);
+                }
+                if (typeof parsed.reduceMotion === "boolean") setReduceMotion(parsed.reduceMotion);
+            } catch {
+                window.localStorage.removeItem(STORAGE_KEY);
+            }
+        }
+    }, []);
+
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        const payload = JSON.stringify({ highContrast, textSize, reduceMotion });
+        window.localStorage.setItem(STORAGE_KEY, payload);
+    }, [highContrast, textSize, reduceMotion]);
+
+    useEffect(() => {
+        if (typeof document === "undefined") return;
+        const root = document.documentElement;
+        root.dataset.contrast = highContrast ? "high" : "default";
+        root.dataset.textSize = textSize;
+        root.dataset.motion = reduceMotion ? "reduced" : "default";
+    }, [highContrast, textSize, reduceMotion]);
+
+    useEffect(() => {
+        if (typeof document === "undefined") return;
+        const root = document.documentElement;
+        const prefersReduced = window.matchMedia?.("(prefers-reduced-motion: reduce)");
+        const update = () => {
+            if (prefersReduced?.matches) {
+                root.dataset.motionPref = "reduced";
+            } else {
+                root.dataset.motionPref = "default";
+            }
+        };
+        update();
+        prefersReduced?.addEventListener?.("change", update);
+        return () => prefersReduced?.removeEventListener?.("change", update);
+    }, []);
+
+    const value = useMemo(
+        () => ({
+            highContrast,
+            setHighContrast,
+            textSize,
+            setTextSize,
+            reduceMotion,
+            setReduceMotion,
+        }),
+        [highContrast, setHighContrast, textSize, setTextSize, reduceMotion, setReduceMotion]
+    );
+
+    return <AccessibilityContext.Provider value={value}>{children}</AccessibilityContext.Provider>;
+}
+
+export function useAccessibility() {
+    const context = useContext(AccessibilityContext);
+    if (!context) {
+        throw new Error("useAccessibility must be used within an AccessibilityProvider");
+    }
+    return context;
+}

--- a/src/app/contexts/I18nContext.tsx
+++ b/src/app/contexts/I18nContext.tsx
@@ -283,12 +283,17 @@ const translations = {
 const I18nContext = createContext<I18nContextValue | undefined>(undefined);
 
 function getTranslationValue(language: Language, key: string) {
-    return key.split(".").reduce((obj, part) => {
-        if (obj && typeof obj === "object" && part in obj) {
-            return (obj as Record<string, unknown>)[part];
+    let current: unknown = translations[language] as Record<string, unknown>;
+
+    for (const part of key.split(".")) {
+        if (current && typeof current === "object" && part in (current as Record<string, unknown>)) {
+            current = (current as Record<string, unknown>)[part];
+        } else {
+            return undefined;
         }
-        return undefined;
-    }, translations[language] as Record<string, unknown>);
+    }
+
+    return current;
 }
 
 function interpolate(message: string, values?: TranslationValues) {

--- a/src/app/contexts/I18nContext.tsx
+++ b/src/app/contexts/I18nContext.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+type Language = "en" | "pt";
+
+type TranslationValues = Record<string, string | number>;
+
+type I18nContextValue = {
+    language: Language;
+    setLanguage: (language: Language) => void;
+    t: (key: string, values?: TranslationValues) => string;
+};
+
+const LANGUAGE_STORAGE_KEY = "theushen-language";
+
+const translations = {
+    en: {
+        nav: {
+            projects: "Projects",
+            timeline: "Timeline",
+            contact: "Contact",
+            backHome: "Back home",
+        },
+        home: {
+            stars: "Stars",
+            support: "Support my portfolio",
+            loading: "Loading...",
+            needHelp: "Need some help?",
+            sendMessage: "Send message",
+            scrollDown: "Scroll down for",
+            aboutMe: "About Me",
+        },
+        about: {
+            titlePrefix: "Hello, I'm ",
+            paragraphOneBeforeMit:
+                "14-year-old student dreaming big and building the future with code. I'm determined to get into ",
+            paragraphOneAfterMit:
+                " with a full-ride scholarship, where I plan to major in Aerospace Engineering and Computer Engineering.",
+            paragraphTwoBeforePracta:
+                "Founder of ",
+            paragraphTwoAfterPracta:
+                ", an open source community that helps students achieve their academic and personal goals with lots of code, collaboration, and resilience.",
+            paragraphThreeBeforeShipwrecked:
+                "I've already developed projects such as viral mutation simulators, digital organizers, and remote diagnosis systems, and I actively participate in hackathons like ",
+            paragraphThreeBetween:
+                " and events from ",
+            paragraphThreeAfterHackClub:
+                ".",
+            paragraphFour:
+                "I'm always looking to learn new technologies, contribute to open source repositories, and grow as a developer and as a person.",
+            paragraphFive:
+                "If you want to chat about programming, science, communities, or how to turn dreams into projects, reach out to me!",
+            hackClubTitle: "Hack Club",
+            hackClubSubtitle: "I'm currently participating in!",
+            timerTitle: "Time left until my College Application",
+        },
+        time: {
+            days: "days",
+            hoursShort: "h",
+            minutesShort: "min",
+            secondsShort: "s",
+        },
+        projects: {
+            title: "Projects",
+            subtitle: "Some of the projects are from work and some are on my own time.",
+            allProjects: "All Projects",
+            filters: "Filters",
+            filterTitle: "Filters",
+            featuredType: "Featured Project Type",
+            openSource: "Open Source",
+            closeSource: "Closed Source",
+            website: "Website",
+            application: "Application",
+            filtersNote: "* Filters above affect only the featured projects.",
+            topics: "Topics",
+            clear: "Clear",
+            previousTopics: "Previous topics page",
+            nextTopics: "Next topics page",
+            clearAll: "Clear All",
+            cancel: "Cancel",
+            applyFilters: "Apply Filters",
+            readMore: "Read more",
+            githubProjects: "GitHub Projects",
+            loadingRepositories: "Loading repositories…",
+            errorRepositories: "Error fetching repositories.",
+            projectWebsite: "Project Website",
+            noDescription: "No description",
+            other: "Other",
+            viewOnGithub: "View {name} on GitHub",
+            githubGists: "GitHub Gists",
+            loadingGists: "Loading gists…",
+            errorGists: "Error fetching gists.",
+            noGists: "No gists found.",
+            untitled: "Untitled",
+            moreFiles: "+{count} more {fileLabel}",
+            fileSingular: "file",
+            filePlural: "files",
+            textLanguage: "Text",
+            practaDescription:
+                "PRACTA is an open-source community focused on helping students prepare for SAT with focus in the MIT university. It provides a platform for students worldwide to discuss study strategies, share experiences, and connect with like-minded individuals.",
+            arcadeDescription:
+                "Arcade Lunar is a social network focused on gaming and multiplayer experiences. It connects players worldwide, offering communities, events, and interactive features.",
+            optifyxDescription:
+                "Optifyx is an app that allows a smartphone to fully monitor a desktop in real-time over a Wi-Fi connection. It provides seamless remote access, ensuring control and visibility.",
+        },
+        timeline: {
+            title: "Timeline",
+            subtitle: "Scroll down to see the timeline. Each point opens the full markdown entry on GitHub.",
+            openOnGithub: "Open {title} on GitHub",
+            cardHint: "Click to open the full entry on GitHub.",
+            emptyState:
+                "No markdown files found in /{folder}. Add files like 2026-01-05.md with a first line heading: '# Title'.",
+        },
+        errors: {
+            title: "Oops!",
+            subtitle: "Something went wrong",
+            fallback: "An unexpected error occurred. Please try again.",
+            tryAgain: "Try Again",
+        },
+        notFound: {
+            title: "Page Not Found",
+            body: "Sorry, the page you're looking for doesn't exist or has been moved.",
+            backHome: "Back to Home",
+        },
+        contact: {
+            github: "GitHub",
+            email: "Email",
+            instagram: "Instagram",
+            linkedin: "LinkedIn",
+        },
+        accessibility: {
+            accessibilityLabel: "Accessibility",
+            translationLabel: "Translation",
+            accessibilityTitle: "Accessibility settings",
+            languageTitle: "Language",
+            languageNotice:
+                "Some project descriptions, repo topics, and GitHub content may remain in English or Portuguese because they are dynamic.",
+            languageEnglish: "English",
+            languagePortuguese: "Português",
+            highContrast: "High contrast",
+            textSize: "Text size",
+            textSizeNormal: "Normal",
+            textSizeLarge: "Large",
+            textSizeXL: "Extra large",
+            reduceMotion: "Reduce motion",
+        },
+    },
+    pt: {
+        nav: {
+            projects: "Projetos",
+            timeline: "Linha do tempo",
+            contact: "Contato",
+            backHome: "Voltar para o início",
+        },
+        home: {
+            stars: "Estrelas",
+            support: "Apoie meu portfólio",
+            loading: "Carregando...",
+            needHelp: "Precisa de ajuda?",
+            sendMessage: "Enviar mensagem",
+            scrollDown: "Role para ver",
+            aboutMe: "Sobre mim",
+        },
+        about: {
+            titlePrefix: "Olá, eu sou o ",
+            paragraphOneBeforeMit:
+                "Estudante de 14 anos sonhando alto e construindo o futuro com código. Estou determinado a entrar no ",
+            paragraphOneAfterMit:
+                " com bolsa integral, onde planejo cursar Engenharia Aeroespacial e Engenharia da Computação.",
+            paragraphTwoBeforePracta:
+                "Fundador da ",
+            paragraphTwoAfterPracta:
+                ", uma comunidade open source que ajuda estudantes a alcançar objetivos acadêmicos e pessoais com muito código, colaboração e resiliência.",
+            paragraphThreeBeforeShipwrecked:
+                "Já desenvolvi projetos como simuladores de mutação viral, organizadores digitais e sistemas de diagnóstico remoto, e participo ativamente de hackathons como ",
+            paragraphThreeBetween:
+                " e eventos do ",
+            paragraphThreeAfterHackClub:
+                ".",
+            paragraphFour:
+                "Estou sempre buscando aprender novas tecnologias, contribuir com repositórios open source e crescer como desenvolvedor e como pessoa.",
+            paragraphFive:
+                "Se você quiser conversar sobre programação, ciência, comunidades ou como transformar sonhos em projetos, fale comigo!",
+            hackClubTitle: "Hack Club",
+            hackClubSubtitle: "Estou participando atualmente!",
+            timerTitle: "Tempo restante até minha aplicação universitária",
+        },
+        time: {
+            days: "dias",
+            hoursShort: "h",
+            minutesShort: "min",
+            secondsShort: "s",
+        },
+        projects: {
+            title: "Projetos",
+            subtitle: "Alguns dos projetos são do trabalho e outros são pessoais.",
+            allProjects: "Todos os projetos",
+            filters: "Filtros",
+            filterTitle: "Filtros",
+            featuredType: "Tipo de projeto em destaque",
+            openSource: "Código aberto",
+            closeSource: "Código fechado",
+            website: "Website",
+            application: "Aplicação",
+            filtersNote: "* Os filtros acima afetam apenas os projetos em destaque.",
+            topics: "Tópicos",
+            clear: "Limpar",
+            previousTopics: "Página anterior de tópicos",
+            nextTopics: "Próxima página de tópicos",
+            clearAll: "Limpar tudo",
+            cancel: "Cancelar",
+            applyFilters: "Aplicar filtros",
+            readMore: "Saiba mais",
+            githubProjects: "Projetos do GitHub",
+            loadingRepositories: "Carregando repositórios…",
+            errorRepositories: "Erro ao buscar repositórios.",
+            projectWebsite: "Website do projeto",
+            noDescription: "Sem descrição",
+            other: "Outro",
+            viewOnGithub: "Ver {name} no GitHub",
+            githubGists: "Gists do GitHub",
+            loadingGists: "Carregando gists…",
+            errorGists: "Erro ao buscar gists.",
+            noGists: "Nenhum gist encontrado.",
+            untitled: "Sem título",
+            moreFiles: "+{count} {fileLabel} a mais",
+            fileSingular: "arquivo",
+            filePlural: "arquivos",
+            textLanguage: "Texto",
+            practaDescription:
+                "A PRACTA é uma comunidade open source focada em ajudar estudantes a se prepararem para o SAT com foco no MIT. Ela oferece uma plataforma para estudantes do mundo todo discutirem estratégias de estudo, compartilharem experiências e se conectarem com pessoas parecidas.",
+            arcadeDescription:
+                "Arcade Lunar é uma rede social voltada para games e experiências multiplayer. Ela conecta jogadores do mundo todo, oferecendo comunidades, eventos e recursos interativos.",
+            optifyxDescription:
+                "Optifyx é um app que permite que um smartphone monitore totalmente um desktop em tempo real via Wi-Fi. Ele oferece acesso remoto contínuo, garantindo controle e visibilidade.",
+        },
+        timeline: {
+            title: "Linha do tempo",
+            subtitle:
+                "Role para ver a linha do tempo. Cada ponto abre a entrada completa em Markdown no GitHub.",
+            openOnGithub: "Abrir {title} no GitHub",
+            cardHint: "Clique para abrir a entrada completa no GitHub.",
+            emptyState:
+                "Nenhum arquivo Markdown encontrado em /{folder}. Adicione arquivos como 2026-01-05.md com a primeira linha sendo: '# Título'.",
+        },
+        errors: {
+            title: "Ops!",
+            subtitle: "Algo deu errado",
+            fallback: "Ocorreu um erro inesperado. Tente novamente.",
+            tryAgain: "Tentar novamente",
+        },
+        notFound: {
+            title: "Página não encontrada",
+            body: "Desculpe, a página que você procura não existe ou foi movida.",
+            backHome: "Voltar para o início",
+        },
+        contact: {
+            github: "GitHub",
+            email: "E-mail",
+            instagram: "Instagram",
+            linkedin: "LinkedIn",
+        },
+        accessibility: {
+            accessibilityLabel: "Acessibilidade",
+            translationLabel: "Tradução",
+            accessibilityTitle: "Configurações de acessibilidade",
+            languageTitle: "Idioma",
+            languageNotice:
+                "Algumas descrições de projetos, tópicos de repositórios e conteúdos do GitHub podem permanecer em inglês ou português por serem dinâmicos.",
+            languageEnglish: "Inglês",
+            languagePortuguese: "Português",
+            highContrast: "Alto contraste",
+            textSize: "Tamanho do texto",
+            textSizeNormal: "Normal",
+            textSizeLarge: "Grande",
+            textSizeXL: "Extra grande",
+            reduceMotion: "Reduzir movimento",
+        },
+    },
+} as const;
+
+const I18nContext = createContext<I18nContextValue | undefined>(undefined);
+
+function getTranslationValue(language: Language, key: string) {
+    return key.split(".").reduce((obj, part) => {
+        if (obj && typeof obj === "object" && part in obj) {
+            return (obj as Record<string, unknown>)[part];
+        }
+        return undefined;
+    }, translations[language] as Record<string, unknown>);
+}
+
+function interpolate(message: string, values?: TranslationValues) {
+    if (!values) return message;
+    return message.replace(/\{(\w+)\}/g, (_, valueKey) => {
+        const replacement = values[valueKey];
+        return replacement !== undefined ? String(replacement) : "";
+    });
+}
+
+export function I18nProvider({ children }: { children: React.ReactNode }) {
+    const [language, setLanguage] = useState<Language>("en");
+
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        const stored = window.localStorage.getItem(LANGUAGE_STORAGE_KEY);
+        if (stored === "en" || stored === "pt") {
+            setLanguage(stored);
+            return;
+        }
+        const browserLang = window.navigator.language.toLowerCase();
+        if (browserLang.startsWith("pt")) {
+            setLanguage("pt");
+        }
+    }, []);
+
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+        document.documentElement.lang = language === "pt" ? "pt-BR" : "en";
+    }, [language]);
+
+    const t = useCallback(
+        (key: string, values?: TranslationValues) => {
+            const current = getTranslationValue(language, key);
+            const fallback = getTranslationValue("en", key);
+            const message = typeof current === "string" ? current : typeof fallback === "string" ? fallback : key;
+            return interpolate(message, values);
+        },
+        [language]
+    );
+
+    const value = useMemo(
+        () => ({
+            language,
+            setLanguage,
+            t,
+        }),
+        [language, setLanguage, t]
+    );
+
+    return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n() {
+    const context = useContext(I18nContext);
+    if (!context) {
+        throw new Error("useI18n must be used within an I18nProvider");
+    }
+    return context;
+}

--- a/src/app/decisions/page.tsx
+++ b/src/app/decisions/page.tsx
@@ -10,6 +10,7 @@ import { EffectCoverflow, Autoplay } from "swiper/modules";
 import { ArrowLeft } from "lucide-react";
 import Particles from "@/app/components/particles";
 import Confetti from "react-confetti";
+import { useI18n } from "@/app/contexts/I18nContext";
 
 // Lista das imagens do carrossel
 const images = [
@@ -64,6 +65,7 @@ function isMobile() {
 }
 
 export default function AutoCarousel() {
+    const { t } = useI18n();
     // Responsividade: define slidesPerView conforme a largura da tela
     const [slidesPerView, setSlidesPerView] = useState(3);
     // Estado para saber se é mobile
@@ -130,10 +132,10 @@ export default function AutoCarousel() {
                 </button>
                 <div className="flex space-x-6">
                     <button className="text-lg hover:text-red-400 transition-colors" onClick={() => window.location.href = '/projects'}>
-                        Projects
+                        {t("nav.projects")}
                     </button>
                     <button className="text-lg hover:text-red-400 transition-colors" onClick={() => window.location.href = '/contact'}>
-                        Contact
+                        {t("nav.contact")}
                     </button>
                 </div>
             </div>
@@ -296,27 +298,27 @@ function TimerSection({
             }}
         >
             <span className="text-lg font-semibold text-red-300 mb-2">
-                Time left until my College Application
+                {t("about.timerTitle")}
             </span>
             <div className="flex gap-3 text-white text-2xl font-mono tracking-wider">
                 <div className="flex flex-col items-center">
                     <span className="timer-value">{timer.days}</span>
-                    <span className="text-xs text-red-400">days</span>
+                    <span className="text-xs text-red-400">{t("time.days")}</span>
                 </div>
                 <span>:</span>
                 <div className="flex flex-col items-center">
                     <span className="timer-value">{timer.hours}</span>
-                    <span className="text-xs text-red-400">h</span>
+                    <span className="text-xs text-red-400">{t("time.hoursShort")}</span>
                 </div>
                 <span>:</span>
                 <div className="flex flex-col items-center">
                     <span className="timer-value">{timer.mins}</span>
-                    <span className="text-xs text-red-400">min</span>
+                    <span className="text-xs text-red-400">{t("time.minutesShort")}</span>
                 </div>
                 <span>:</span>
                 <div className="flex flex-col items-center">
                     <span className="timer-value">{timer.secs}</span>
-                    <span className="text-xs text-red-400">s</span>
+                    <span className="text-xs text-red-400">{t("time.secondsShort")}</span>
                 </div>
             </div>
         </div>

--- a/src/app/decisions/page.tsx
+++ b/src/app/decisions/page.tsx
@@ -243,6 +243,7 @@ function TimerSection({
     targetDate: Date;
     onTimerZero: () => void;
 }) {
+    const { t } = useI18n();
     // Inicializa o timer "hidratado" já no client, usando um fallback estável no SSR
     const [timer, setTimer] = useState(() =>
         typeof window === "undefined"

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,4 +1,6 @@
-'use client';
+"use client";
+
+import { useI18n } from "./contexts/I18nContext";
 
 export default function Error({
   error,
@@ -7,21 +9,23 @@ export default function Error({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const { t } = useI18n();
+
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gradient-to-br from-black via-zinc-900 to-black text-white px-4">
       <div className="text-center max-w-md">
         <h1 className="text-6xl font-bold bg-gradient-to-r from-red-500 to-red-700 bg-clip-text text-transparent mb-4">
-          Oops!
+          {t("errors.title")}
         </h1>
-        <h2 className="text-2xl font-semibold mb-4">Something went wrong</h2>
+        <h2 className="text-2xl font-semibold mb-4">{t("errors.subtitle")}</h2>
         <p className="text-zinc-400 mb-8">
-          {error.message || "An unexpected error occurred. Please try again."}
+          {error.message || t("errors.fallback")}
         </p>
         <button
           onClick={reset}
           className="inline-block bg-red-600 hover:bg-red-700 text-white font-semibold px-8 py-3 rounded-lg transition-all duration-200 transform hover:scale-105"
         >
-          Try Again
+          {t("errors.tryAgain")}
         </button>
       </div>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,6 +15,31 @@ body {
   text-rendering: optimizeSpeed;
 }
 
+html[data-text-size="large"] {
+  font-size: 112.5%;
+}
+
+html[data-text-size="xl"] {
+  font-size: 125%;
+}
+
+html[data-contrast="high"] body {
+  background-color: #000000 !important;
+  color: #ffffff !important;
+}
+
+html[data-contrast="high"] a,
+html[data-contrast="high"] button {
+  color: #ffffff;
+}
+
+html[data-motion="reduced"] * {
+  animation-duration: 0.001ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.001ms !important;
+  scroll-behavior: auto !important;
+}
+
 /* Optimize animations */
 @media (prefers-reduced-motion: no-preference) {
   * {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,9 +3,12 @@ import Script from "next/script";
 import CollegeDecisionsBar from "./components/CollegeDecisionsBar";
 import GlobalSwitch from "./components/Switch";
 import InspectDetector from "./components/InspectDetector";
+import FloatingControls from "./components/FloatingControls";
 import "./globals.css";
 import { PostHogProvider } from "./providers/PostHogProvider";
 import { GlobeProvider } from "./contexts/GlobeContext";
+import { I18nProvider } from "./contexts/I18nContext";
+import { AccessibilityProvider } from "./contexts/AccessibilityContext";
 
 export const metadata: Metadata = {
     title: {
@@ -212,12 +215,17 @@ export default function RootLayout({
         </head>
         <body className="antialiased font-sans">
         <PostHogProvider>
-            <GlobeProvider>
-                <InspectDetector />
-                <CollegeDecisionsBar />
-                <GlobalSwitch />
-                {children}
-            </GlobeProvider>
+            <I18nProvider>
+                <AccessibilityProvider>
+                    <GlobeProvider>
+                        <InspectDetector />
+                        <CollegeDecisionsBar />
+                        <GlobalSwitch />
+                        <FloatingControls />
+                        {children}
+                    </GlobeProvider>
+                </AccessibilityProvider>
+            </I18nProvider>
         </PostHogProvider>
         
         {/* Service Worker Registration */}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,19 +1,25 @@
+"use client";
+
+import { useI18n } from "./contexts/I18nContext";
+
 export default function NotFound() {
+  const { t } = useI18n();
+
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gradient-to-br from-black via-zinc-900 to-black text-white px-4">
       <div className="text-center">
         <h1 className="text-9xl font-bold bg-gradient-to-r from-red-500 to-red-700 bg-clip-text text-transparent mb-4">
           404
         </h1>
-        <h2 className="text-3xl font-semibold mb-4">Page Not Found</h2>
+        <h2 className="text-3xl font-semibold mb-4">{t("notFound.title")}</h2>
         <p className="text-zinc-400 mb-8 max-w-md">
-          Sorry, the page you're looking for doesn't exist or has been moved.
+          {t("notFound.body")}
         </p>
         <a
           href="/"
           className="inline-block bg-red-600 hover:bg-red-700 text-white font-semibold px-8 py-3 rounded-lg transition-all duration-200 transform hover:scale-105"
         >
-          Back to Home
+          {t("notFound.backHome")}
         </a>
       </div>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import dynamic from 'next/dynamic';
 import './index.css'
 import LoadingDots from "./components/LoadingDots";
 import ClientRemount from "./client-remount";
+import { useI18n } from "./contexts/I18nContext";
 
 // Lazy load components
 const Particles = dynamic(() => import("./components/particles"), { 
@@ -22,9 +23,9 @@ const About = dynamic(() => import("./pages/about"), {
 // This site was inspired by chronark/chronark.com and uses some code snippets from it, not only in this file but also in others.
 
 const navigation = [
-    { name: "Projects", href: "/projects" },
-    { name: "Timeline", href: "/timeline" },
-    { name: "Contact", href: "/contact" },
+    { key: "nav.projects", href: "/projects" },
+    { key: "nav.timeline", href: "/timeline" },
+    { key: "nav.contact", href: "/contact" },
 ];
 
 // Set your user and repository here
@@ -32,6 +33,7 @@ const REPO_OWNER = "TheusHen";
 const REPO_NAME = "TheusHen";
 
 export default function Home() {
+    const { t } = useI18n();
     const [message, setMessage] = useState("");
     const [stars, setStars] = useState<number | null>(null);
 
@@ -102,13 +104,13 @@ export default function Home() {
                         {stars !== null ? (
                             <>
                                 <span className="font-bold">{stars}</span>
-                                <span className="hidden sm:inline">Stars</span>
-                                <span className="ml-2 text-yellow-700/90 group-hover:text-yellow-900 transition-colors">Support my portfolio</span>
+                                <span className="hidden sm:inline">{t("home.stars")}</span>
+                                <span className="ml-2 text-yellow-700/90 group-hover:text-yellow-900 transition-colors">{t("home.support")}</span>
                             </>
                         ) : (
                             <span className="inline-flex items-center gap-1">
                                 <LoadingDots color="#f59e42" size={7} />
-                                <span className="hidden sm:inline ml-1">Loading...</span>
+                                <span className="hidden sm:inline ml-1">{t("home.loading")}</span>
                             </span>
                         )}
                     </span>
@@ -126,7 +128,7 @@ export default function Home() {
                                         href={item.href}
                                         className="text-xs sm:text-sm duration-500 text-zinc-400 hover:text-zinc-200 focus:outline-none focus:text-white transition-colors px-3 py-1 rounded"
                                     >
-                                        {item.name}
+                                        {t(item.key)}
                                     </Link>
                                 </li>
                             ))}
@@ -146,7 +148,7 @@ export default function Home() {
                     <div className="flex items-center bg-white/70 rounded-full p-1.5 shadow w-full max-w-md mt-8 sm:max-w-xs border border-zinc-200 backdrop-blur">
                         <input
                             type="text"
-                            placeholder="Need some help?"
+                            placeholder={t("home.needHelp")}
                             value={message}
                             onChange={(e) => setMessage(e.target.value)}
                             className="flex-1 bg-transparent outline-none text-black px-3 text-sm sm:text-xs placeholder:text-black-500"
@@ -154,7 +156,7 @@ export default function Home() {
                         <button
                             onClick={handleSend}
                             className="bg-black/80 hover:bg-black text-white p-2 rounded-full flex items-center justify-center transition-colors duration-200"
-                            aria-label="Send message"
+                            aria-label={t("home.sendMessage")}
                         >
                             <ArrowUp size={18} />
                         </button>
@@ -167,7 +169,7 @@ export default function Home() {
                     >
                         <ArrowDownCircle size={32} className="text-zinc-400 hover:text-zinc-200 transition-all duration-200" />
                         <span className="mt-1 text-zinc-400 text-xs sm:text-sm font-medium">
-                        Scroll down for <span className="font-semibold text-zinc-200">About Me</span>
+                        {t("home.scrollDown")} <span className="font-semibold text-zinc-200">{t("home.aboutMe")}</span>
                     </span>
                     </div>
                 </div>

--- a/src/app/pages/about.tsx
+++ b/src/app/pages/about.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState, memo } from "react";
 import { gsap } from "gsap";
 import Image from "next/image";
 import dynamic from "next/dynamic";
+import { useI18n } from "../contexts/I18nContext";
 
 // Lazy load heavy components
 const Fall = dynamic(() => import("../components/Fall"), { 
@@ -83,6 +84,7 @@ const MemoizedProfileImage = memo(ProfileImage);
 
 function TextSection() {
     const textRef = useRef<HTMLDivElement>(null);
+    const { t } = useI18n();
 
     useEffect(() => {
         if (textRef.current)
@@ -99,23 +101,32 @@ function TextSection() {
             className="flex-1 p-8 flex flex-col gap-2 justify-center"
         >
             <h1 className="text-4xl md:text-5xl font-extrabold text-white mb-4 drop-shadow-lg">
-                Hello, I&apos;m <span className="text-red-800">TheusHen</span>!
+                {t("about.titlePrefix")}
+                <span className="text-red-800">TheusHen</span>!
             </h1>
             <div className="flex flex-col gap-3 text-lg md:text-xl text-white/90 mb-2 leading-relaxed">
                 <span>
-                    14-year-old student dreaming big and building the future with code. I&apos;m determined to get into <span className="font-bold text-red-600">MIT</span> with a full-ride scholarship, where I plan to major in Aerospace Engineering and Computer Engineering.
+                    {t("about.paragraphOneBeforeMit")}
+                    <span className="font-bold text-red-600">MIT</span>
+                    {t("about.paragraphOneAfterMit")}
                 </span>
                 <span>
-                    Founder of <span className="font-bold text-red-600">PRACTA</span>, an open source community that helps students achieve their academic and personal goals with lots of code, collaboration, and resilience.
+                    {t("about.paragraphTwoBeforePracta")}
+                    <span className="font-bold text-red-600">PRACTA</span>
+                    {t("about.paragraphTwoAfterPracta")}
                 </span>
                 <span>
-                    I&apos;ve already developed projects such as viral mutation simulators, digital organizers, and remote diagnosis systems, and I actively participate in hackathons like <span className="text-red-600 font-bold">Shipwrecked</span> and events from <span className="text-red-600 font-bold">Hack Club</span>.
+                    {t("about.paragraphThreeBeforeShipwrecked")}
+                    <span className="text-red-600 font-bold">Shipwrecked</span>
+                    {t("about.paragraphThreeBetween")}
+                    <span className="text-red-600 font-bold">Hack Club</span>
+                    {t("about.paragraphThreeAfterHackClub")}
                 </span>
                 <span>
-                    I&apos;m always looking to learn new technologies, contribute to open source repositories, and grow as a developer and as a person.
+                    {t("about.paragraphFour")}
                 </span>
                 <span>
-                    If you want to chat about programming, science, communities, or how to turn dreams into projects, reach out to me!
+                    {t("about.paragraphFive")}
                 </span>
             </div>
             <div className="flex gap-4 mt-4">
@@ -154,6 +165,7 @@ const MemoizedTextSection = memo(TextSection);
 
 function HackClubSection() {
     const hackRef = useRef<HTMLDivElement>(null);
+    const { t } = useI18n();
 
     useEffect(() => {
         if (hackRef.current)
@@ -178,8 +190,8 @@ function HackClubSection() {
                 loading="lazy"
             />
             <div>
-                <span className="text-2xl font-bold text-red-300">Hack Club</span>
-                <p className="text-white/80 text-base mt-1">I&apos;m currently participating in!</p>
+                <span className="text-2xl font-bold text-red-300">{t("about.hackClubTitle")}</span>
+                <p className="text-white/80 text-base mt-1">{t("about.hackClubSubtitle")}</p>
             </div>
         </div>
     );
@@ -190,6 +202,7 @@ const MemoizedHackClubSection = memo(HackClubSection);
 function TimerSection() {
     const [timer, setTimer] = useState({ days: 0, hours: 0, mins: 0, secs: 0 });
     const timerRef = useRef<HTMLDivElement>(null);
+    const { t } = useI18n();
 
     useEffect(() => {
         setTimer(getTimeLeft());
@@ -211,26 +224,26 @@ function TimerSection() {
             ref={timerRef}
             className="flex flex-col h-40 items-center justify-center bg-zinc-900/80 backdrop-blur-lg rounded-xl p-6 shadow-lg border border-red-400/20"
         >
-            <span className="text-lg font-semibold text-red-300 mb-2">Time left until my College Application</span>
+            <span className="text-lg font-semibold text-red-300 mb-2">{t("about.timerTitle")}</span>
             <div className="flex gap-3 text-white text-2xl font-mono tracking-wider">
                 <div className="flex flex-col items-center">
                     <span>{timer.days}</span>
-                    <span className="text-xs text-red-400">days</span>
+                    <span className="text-xs text-red-400">{t("time.days")}</span>
                 </div>
                 <span>:</span>
                 <div className="flex flex-col items-center">
                     <span>{timer.hours}</span>
-                    <span className="text-xs text-red-400">h</span>
+                    <span className="text-xs text-red-400">{t("time.hoursShort")}</span>
                 </div>
                 <span>:</span>
                 <div className="flex flex-col items-center">
                     <span>{timer.mins}</span>
-                    <span className="text-xs text-red-400">min</span>
+                    <span className="text-xs text-red-400">{t("time.minutesShort")}</span>
                 </div>
                 <span>:</span>
                 <div className="flex flex-col items-center">
                     <span>{timer.secs}</span>
-                    <span className="text-xs text-red-400">s</span>
+                    <span className="text-xs text-red-400">{t("time.secondsShort")}</span>
                 </div>
             </div>
         </div>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -11,6 +11,7 @@ import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
 import './styles.css'
 
 import { cn } from "@/app/lib/cn";
+import { useI18n } from "@/app/contexts/I18nContext";
 
 // --- ScrollArea definition ---
 const ScrollArea = React.forwardRef<
@@ -105,14 +106,15 @@ const ProjectsPage = () => {
     const [gists, setGists] = useState<Gist[]>([]);
     const [loading, setLoading] = useState(true);
     const [loadingGists, setLoadingGists] = useState(true);
-    const [error, setError] = useState<string | null>(null);
-    const [gistsError, setGistsError] = useState<string | null>(null);
+    const [error, setError] = useState(false);
+    const [gistsError, setGistsError] = useState(false);
     const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
     const [allTopics, setAllTopics] = useState<string[]>([]);
 
     // New: Topics navigation state
     const [topicsPage, setTopicsPage] = useState(0);
     const TOPICS_PER_PAGE = 10;
+    const { t } = useI18n();
 
     const gridRef = useRef<HTMLDivElement>(null);
 
@@ -187,14 +189,14 @@ const ProjectsPage = () => {
                     });
                     setAllTopics(Array.from(topics).sort());
 
-                    setError(null);
+                    setError(false);
                 } else {
-                    setError("Error fetching repositories.");
+                    setError(true);
                 }
                 setLoading(false);
             })
             .catch(() => {
-                setError("Error fetching repositories.");
+                setError(true);
                 setLoading(false);
             });
         
@@ -205,14 +207,14 @@ const ProjectsPage = () => {
             .then((data) => {
                 if (Array.isArray(data)) {
                     setGists(data);
-                    setGistsError(null);
+                    setGistsError(false);
                 } else {
-                    setGistsError("Error fetching gists.");
+                    setGistsError(true);
                 }
                 setLoadingGists(false);
             })
             .catch(() => {
-                setGistsError("Error fetching gists.");
+                setGistsError(true);
                 setLoadingGists(false);
             });
     }, []);
@@ -290,36 +292,36 @@ const ProjectsPage = () => {
             <div className="max-w-6xl mx-auto p-6">
                 {/* Header */}
                 <div className="flex justify-between items-center mb-6 animate-fade-in">
-                    <button className="text-2xl cursor-pointer transition-transform hover:-translate-x-1 text-white" onClick={() => window.location.href = '/'}>
-                        <ArrowLeft />
-                    </button>
-                    <div className="flex space-x-6">
-                        <button className="text-lg hover:text-red-400 transition-colors" onClick={() => window.location.href = '/projects'}>
-                            Projects
+                        <button className="text-2xl cursor-pointer transition-transform hover:-translate-x-1 text-white" onClick={() => window.location.href = '/'}>
+                            <ArrowLeft />
                         </button>
-                        <button className="text-lg hover:text-red-400 transition-colors" onClick={() => window.location.href = '/contact'}>
-                            Contact
-                        </button>
+                        <div className="flex space-x-6">
+                            <button className="text-lg hover:text-red-400 transition-colors" onClick={() => window.location.href = '/projects'}>
+                                {t("nav.projects")}
+                            </button>
+                            <button className="text-lg hover:text-red-400 transition-colors" onClick={() => window.location.href = '/contact'}>
+                                {t("nav.contact")}
+                            </button>
+                        </div>
                     </div>
-                </div>
 
                 {/* Title */}
                 <h1 className="text-6xl font-extrabold text-white mb-2 animate-fade-in">
-                    Projects
+                    {t("projects.title")}
                 </h1>
                 <p className="text-xl text-gray-400 mb-6 animate-fade-in">
-                    Some of the projects are from work and some are on my own time.
+                    {t("projects.subtitle")}
                 </p>
 
                 {/* Filters */}
                 <div className="flex justify-between items-center mb-6 border-b border-gray-700 pb-2">
-                    <span className="text-lg text-gray-300">All Projects</span>
+                    <span className="text-lg text-gray-300">{t("projects.allProjects")}</span>
                     <div
                         className="flex items-center space-x-2 cursor-pointer transition-colors hover:text-red-400"
                         onClick={toggleFilterMenu}
                     >
                         <Filter size={16} />
-                        <span>Filters</span>
+                        <span>{t("projects.filters")}</span>
                     </div>
                 </div>
 
@@ -337,7 +339,7 @@ const ProjectsPage = () => {
                             <div className="bg-gray-900/95 backdrop-blur-md border border-gray-700 rounded-2xl shadow-2xl">
                                 {/* Header */}
                                 <div className="flex items-center justify-between p-6 border-b border-gray-700">
-                                    <h3 className="text-xl font-semibold text-white">Filters</h3>
+                                    <h3 className="text-xl font-semibold text-white">{t("projects.filterTitle")}</h3>
                                     <button
                                         onClick={toggleFilterMenu}
                                         className="text-gray-400 hover:text-white transition-colors p-1 hover:bg-gray-800 rounded-lg"
@@ -350,7 +352,7 @@ const ProjectsPage = () => {
                                 <div className="p-6 space-y-6">
                                     {/* Featured Project Types */}
                                     <div>
-                                        <h4 className="text-sm font-medium text-gray-300 mb-3">Featured Project Type</h4>
+                                        <h4 className="text-sm font-medium text-gray-300 mb-3">{t("projects.featuredType")}</h4>
                                         <div className="grid grid-cols-2 gap-3">
                                             <label className="flex items-center space-x-3 p-3 rounded-lg border border-gray-700 hover:border-gray-600 transition-colors cursor-pointer">
                                                 <input
@@ -359,7 +361,7 @@ const ProjectsPage = () => {
                                                     onChange={(e) => setOpenSource(e.target.checked)}
                                                     className="w-4 h-4 text-red-500 bg-gray-800 border-gray-600 rounded focus:ring-red-500 focus:ring-2"
                                                 />
-                                                <span className="text-sm text-gray-300">Open Source</span>
+                                                <span className="text-sm text-gray-300">{t("projects.openSource")}</span>
                                             </label>
                                             <label className="flex items-center space-x-3 p-3 rounded-lg border border-gray-700 hover:border-gray-600 transition-colors cursor-pointer">
                                                 <input
@@ -368,7 +370,7 @@ const ProjectsPage = () => {
                                                     onChange={(e) => setCloseSource(e.target.checked)}
                                                     className="w-4 h-4 text-red-500 bg-gray-800 border-gray-600 rounded focus:ring-red-500 focus:ring-2"
                                                 />
-                                                <span className="text-sm text-gray-300">Close Source</span>
+                                                <span className="text-sm text-gray-300">{t("projects.closeSource")}</span>
                                             </label>
                                             <label className="flex items-center space-x-3 p-3 rounded-lg border border-gray-700 hover:border-gray-600 transition-colors cursor-pointer">
                                                 <input
@@ -377,7 +379,7 @@ const ProjectsPage = () => {
                                                     onChange={(e) => setWebsite(e.target.checked)}
                                                     className="w-4 h-4 text-red-500 bg-gray-800 border-gray-600 rounded focus:ring-red-500 focus:ring-2"
                                                 />
-                                                <span className="text-sm text-gray-300">Website</span>
+                                                <span className="text-sm text-gray-300">{t("projects.website")}</span>
                                             </label>
                                             <label className="flex items-center space-x-3 p-3 rounded-lg border border-gray-700 hover:border-gray-600 transition-colors cursor-pointer">
                                                 <input
@@ -386,11 +388,11 @@ const ProjectsPage = () => {
                                                     onChange={(e) => setApplication(e.target.checked)}
                                                     className="w-4 h-4 text-red-500 bg-gray-800 border-gray-600 rounded focus:ring-red-500 focus:ring-2"
                                                 />
-                                                <span className="text-sm text-gray-300">Application</span>
+                                                <span className="text-sm text-gray-300">{t("projects.application")}</span>
                                             </label>
                                         </div>
                                         <div className="text-xs text-gray-500 mt-2">
-                                            <span>* Filters above affect only the featured projects.</span>
+                                            <span>{t("projects.filtersNote")}</span>
                                         </div>
                                     </div>
 
@@ -398,13 +400,13 @@ const ProjectsPage = () => {
                                     {allTopics.length > 0 && (
                                         <div>
                                             <div className="flex items-center justify-between mb-3">
-                                                <h4 className="text-sm font-medium text-gray-300">Topics</h4>
+                                                <h4 className="text-sm font-medium text-gray-300">{t("projects.topics")}</h4>
                                                 {selectedTopics.length > 0 && (
                                                     <button
                                                         onClick={() => setSelectedTopics([])}
                                                         className="text-xs text-red-400 hover:text-red-300 transition-colors"
                                                     >
-                                                        Clear ({selectedTopics.length})
+                                                        {t("projects.clear")} ({selectedTopics.length})
                                                     </button>
                                                 )}
                                             </div>
@@ -414,7 +416,7 @@ const ProjectsPage = () => {
                                                     className="mr-2 p-1 rounded hover:bg-gray-700 disabled:opacity-40"
                                                     onClick={goPrevTopics}
                                                     disabled={topicsPage === 0}
-                                                    aria-label="Previous topics page"
+                                                    aria-label={t("projects.previousTopics")}
                                                     type="button"
                                                 >
                                                     <ArrowLeft size={18} />
@@ -424,7 +426,7 @@ const ProjectsPage = () => {
                                                     className="ml-2 p-1 rounded hover:bg-gray-700 disabled:opacity-40"
                                                     onClick={goNextTopics}
                                                     disabled={topicsPage >= totalTopicsPages - 1}
-                                                    aria-label="Next topics page"
+                                                    aria-label={t("projects.nextTopics")}
                                                     type="button"
                                                 >
                                                     <ArrowRight size={18} />
@@ -459,20 +461,20 @@ const ProjectsPage = () => {
                                         onClick={clearAllFilters}
                                         className="text-sm text-gray-400 hover:text-white transition-colors"
                                     >
-                                        Clear All
+                                        {t("projects.clearAll")}
                                     </button>
                                     <div className="flex space-x-3">
                                         <button
                                             onClick={toggleFilterMenu}
                                             className="px-4 py-2 text-sm text-gray-300 hover:text-white transition-colors"
                                         >
-                                            Cancel
+                                            {t("projects.cancel")}
                                         </button>
                                         <button
                                             className="px-6 py-2 bg-red-600 hover:bg-red-700 text-white text-sm rounded-lg transition-colors"
                                             onClick={applyFilters}
                                         >
-                                            Apply Filters
+                                            {t("projects.applyFilters")}
                                         </button>
                                     </div>
                                 </div>
@@ -499,10 +501,7 @@ const ProjectsPage = () => {
                                 </div>
                                 <h2 className="text-2xl font-bold text-white mb-4">PRACTA</h2>
                                 <p className="text-gray-300 text-sm mb-4">
-                                    PRACTA is an open-source community focused on helping students
-                                    prepare for SAT with focus in the MIT university. It provides a platform for students worldwide to discuss
-                                    study strategies, share experiences, and connect with like-minded
-                                    individuals.
+                                    {t("projects.practaDescription")}
                                 </p>
                                 <a
                                     className="text-sm flex items-center space-x-1 hover:underline cursor-pointer text-red-400 hover:text-red-300 transition-colors"
@@ -510,7 +509,7 @@ const ProjectsPage = () => {
                                     target="_blank"
                                     rel="noreferrer"
                                 >
-                                    <span>Read more</span>
+                                    <span>{t("projects.readMore")}</span>
                                     <ArrowRight size={14} />
                                 </a>
                             </div>
@@ -539,9 +538,7 @@ const ProjectsPage = () => {
                                         Arcade Lunar
                                     </h2>
                                     <p className="text-gray-300 text-sm">
-                                        Arcade Lunar is a social network focused on gaming and
-                                        multiplayer experiences. It connects players worldwide,
-                                        offering communities, events, and interactive features.
+                                        {t("projects.arcadeDescription")}
                                     </p>
                                 </div>
                             </a>
@@ -565,9 +562,7 @@ const ProjectsPage = () => {
                                     />
                                     <h2 className="text-2xl font-bold text-white mb-2">Optifyx</h2>
                                     <p className="text-gray-300 text-sm">
-                                        Optifyx is an app that allows a smartphone to fully monitor a
-                                        desktop in real-time over a Wi-Fi connection. It provides
-                                        seamless remote access, ensuring control and visibility.
+                                        {t("projects.optifyxDescription")}
                                     </p>
                                 </div>
                             </a>
@@ -577,12 +572,12 @@ const ProjectsPage = () => {
 
                 {/* GitHub Projects */}
                 <h2 className="text-3xl font-extrabold mt-10 mb-6 text-white">
-                    GitHub Projects
+                    {t("projects.githubProjects")}
                 </h2>
                 {loading ? (
-                    <div className="text-gray-400">Loading repositories…</div>
+                    <div className="text-gray-400">{t("projects.loadingRepositories")}</div>
                 ) : error ? (
-                    <div className="text-red-400">{error}</div>
+                    <div className="text-red-400">{t("projects.errorRepositories")}</div>
                 ) : (
                     <div
                         ref={gridRef}
@@ -615,7 +610,7 @@ const ProjectsPage = () => {
                                                 target="_blank"
                                                 rel="noreferrer"
                                                 className="ml-auto text-red-400 hover:text-red-300 transition-colors"
-                                                title="Project Website"
+                                                title={t("projects.projectWebsite")}
                                                 onClick={e => e.stopPropagation()}
                                             >
                                                 <ExternalLink size={16} />
@@ -623,7 +618,7 @@ const ProjectsPage = () => {
                                         )}
                                     </div>
                                     <p className="flex-1 text-gray-300 text-sm mb-4">
-                                        {repo.description || <span className="italic text-gray-500">No description</span>}
+                                        {repo.description || <span className="italic text-gray-500">{t("projects.noDescription")}</span>}
                                     </p>
 
                                     {/* Topics */}
@@ -647,7 +642,7 @@ const ProjectsPage = () => {
 
                                     <div className="flex justify-between items-end mt-auto">
                                         <span className="text-xs px-2 py-1 rounded bg-red-600 text-white">
-                                            {repo.language ?? "Other"}
+                                            {repo.language ?? t("projects.other")}
                                         </span>
                                         <span className="flex items-center text-xs text-red-400 font-bold">
                                             <Star className="mr-1" size={12} /> {repo.stargazers_count}
@@ -659,7 +654,7 @@ const ProjectsPage = () => {
                                         target="_blank"
                                         rel="noreferrer"
                                         className="absolute inset-0"
-                                        aria-label={`View ${repo.name} on GitHub`}
+                                        aria-label={t("projects.viewOnGithub", { name: repo.name })}
                                         style={{ zIndex: 10 }}
                                     />
                                 </div>
@@ -670,20 +665,22 @@ const ProjectsPage = () => {
 
                 {/* GitHub Gists Section */}
                 <h2 className="text-3xl font-extrabold mt-16 mb-6 text-white">
-                    GitHub Gists
+                    {t("projects.githubGists")}
                 </h2>
                 {loadingGists ? (
-                    <div className="text-gray-400">Loading gists…</div>
+                    <div className="text-gray-400">{t("projects.loadingGists")}</div>
                 ) : gistsError ? (
-                    <div className="text-red-400">{gistsError}</div>
+                    <div className="text-red-400">{t("projects.errorGists")}</div>
                 ) : gists.length === 0 ? (
-                    <div className="text-gray-400">No gists found.</div>
+                    <div className="text-gray-400">{t("projects.noGists")}</div>
                 ) : (
                     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
                         {gists.map((gist) => {
                             const firstFile = Object.values(gist.files)[0];
                             const fileCount = Object.keys(gist.files).length;
-                            const mainLanguage = firstFile?.language || "Text";
+                            const mainLanguage = firstFile?.language || t("projects.textLanguage");
+                            const fileLabel =
+                                fileCount - 1 === 1 ? t("projects.fileSingular") : t("projects.filePlural");
 
                             return (
                                 <a
@@ -707,17 +704,17 @@ const ProjectsPage = () => {
                                             />
                                             <div className="flex-1 min-w-0">
                                                 <span className="text-sm font-semibold text-white block truncate">
-                                                    {firstFile?.filename || "Untitled"}
+                                                    {firstFile?.filename || t("projects.untitled")}
                                                 </span>
                                                 {fileCount > 1 && (
                                                     <span className="text-xs text-gray-400">
-                                                        +{fileCount - 1} more file{fileCount > 2 ? 's' : ''}
+                                                        {t("projects.moreFiles", { count: fileCount - 1, fileLabel })}
                                                     </span>
                                                 )}
                                             </div>
                                         </div>
                                         <p className="flex-1 text-gray-300 text-sm mb-4 line-clamp-3">
-                                            {gist.description || <span className="italic text-gray-500">No description</span>}
+                                            {gist.description || <span className="italic text-gray-500">{t("projects.noDescription")}</span>}
                                         </p>
                                         <div className="flex justify-between items-end">
                                             <span className="text-xs px-2 py-1 rounded bg-red-600 text-white">

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -1,15 +1,15 @@
+"use client";
+
 import React from "react";
-import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import Particles from "../components/particles";
 import Timeline from "../components/Timeline";
-
-export const metadata: Metadata = {
-    title: "Timeline",
-};
+import { useI18n } from "../contexts/I18nContext";
 
 export default function TimelinePage() {
+    const { t } = useI18n();
+
     return (
         <div className="relative min-h-screen bg-gradient-to-b from-black via-zinc-900/60 to-black text-white">
             <Particles className="absolute inset-0 -z-10 opacity-60" quantity={70} />
@@ -19,7 +19,7 @@ export default function TimelinePage() {
                     className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-2 text-sm font-medium text-white transition hover:border-white/25 hover:bg-white/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/70"
                 >
                     <ArrowLeft className="h-4 w-4" />
-                    Back home
+                    {t("nav.backHome")}
                 </Link>
             </div>
             <div className="relative">


### PR DESCRIPTION
### Motivation
- Provide a site-wide, persistent translation system and accessibility features (contrast, text size, reduced motion) so visitors can switch language and adjust visual settings across all pages.
- Expose an attractive, animated pair of floating controls (accessibility + translation) that expand on hover/click and remain available on every page.
- Ensure translations are available for UI copy across main pages and make accessibility preferences persistent and applied via CSS hooks.

### Description
- Added an `I18nProvider` and `useI18n` with English and Portuguese string catalogs and persistent selection stored under `theushen-language` in `localStorage` and wired it into the root layout via `I18nProvider` (new file `src/app/contexts/I18nContext.tsx`).
- Added an `AccessibilityProvider` and `useAccessibility` to persist and expose `highContrast`, `textSize`, and `reduceMotion` settings (new file `src/app/contexts/AccessibilityContext.tsx`) and applied those preferences to `document.documentElement.dataset` for CSS-driven behavior.
- Implemented a new floating UI component `FloatingControls` that shows two circular buttons (accessibility and language) which expand to panels with options and notices; it uses `useI18n` and `useAccessibility` and is included in the global layout so it appears on every page (new file `src/app/components/FloatingControls.tsx`, injected in `src/app/layout.tsx`).
- Localized UI strings and integrated translation calls (`t(...)`) into multiple pages/components including Home, About, Projects, Timeline, Contact, Error, and NotFound, updating copy and a few composed strings where needed (multiple files updated under `src/app/`).
- Added minimal accessibility CSS hooks to `src/app/globals.css` to react to `data-text-size`, `data-contrast`, and `data-motion` attributes for global text scaling, high-contrast styling, and reduced-motion behavior.

### Testing
- Started the dev server with `npm run dev` and confirmed Next compiled and served pages (dev server started and served `/` with 200 responses); this succeeded but external image requests failed due to network reachability (observed 500 responses for some remote images). 
- Ran a Playwright script to visit the local site and capture a screenshot of the floating controls which produced the artifact `artifacts/floating-controls.png`, showing the controls rendered; screenshot capture succeeded.
- No unit or integration test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ad747c0e48328916ae7d9beb7a78b)